### PR TITLE
Enabling debugging

### DIFF
--- a/src/edge-cs/EdgeCompiler.cs
+++ b/src/edge-cs/EdgeCompiler.cs
@@ -48,7 +48,23 @@ public class EdgeCompiler
             }
         }
 
-        string lineDirective = fileName != string.Empty ? "#line 1 " + "\"" + fileName + "\"\n" : string.Empty;
+        string jsFileNameStr = string.Empty;
+        object jsFileName;
+        int? jsLineNumber = null;
+        if (parameters.TryGetValue("jsFileName", out jsFileName))
+        {
+            jsFileNameStr = (string)jsFileName;
+            jsLineNumber = (int)parameters["jsLineNumber"];
+        }
+
+        
+        int lineNumber = 1;
+        if (jsFileNameStr != string.Empty)
+        {
+            fileName = jsFileNameStr;
+            lineNumber = jsLineNumber.Value;
+        }
+        string lineDirective = fileName != string.Empty ? string.Format("#line {0} \"{1}\"\n", lineNumber, fileName) : string.Empty;
         // try to compile source code as a class library
         Assembly assembly;
         string errorsClass;


### PR DESCRIPTION
This enables debugging for:
- Classes/lambdas included in External cx/csx files
- C# classes/lambdas embedded in the javascript

This is enabled by:
- Turning on IncludeDebugInformation in the parameters passed to the Codedom compiler
- Including #line directives at the top of the file for classes and just before the code declaring a Func<object, Task<object>> in the case of lambdas

Debugging of embedded c# code is dependent upon a change to edge to pass through jsFileName and jsLineNumber parameters corresponding to where this code is within the javascript file.

With these changes, if a debugger is attached to the node process, a breakpoint within c# code embedded or in an external cs/csx file will be hit.

ref: tjanczuk/edge#6
