### PR TITLE
Don't blow up if assemblies can't be found

### DIFF
--- a/src/edge-cs/EdgeCompiler.cs
+++ b/src/edge-cs/EdgeCompiler.cs
@@ -28,8 +28,16 @@ public class EdgeCompiler
     {
         Assembly result = null;
         Dictionary<string, Assembly> requesting;
+
+        if (args.RequestingAssembly == null || args.RequestingAssembly.FullName == null)
+        {
+            return null;
+        }
+
         if (referencedAssemblies.TryGetValue(args.RequestingAssembly.FullName, out requesting))
         {
+            if (requesting == null) return null;
+
             requesting.TryGetValue(args.Name, out result);
         }
 


### PR DESCRIPTION
If a C# library attempts to load a library that doesn't exist via `Assembly.Load`, instead of it failing it crashes in edge-cs - ReactiveUI and Akavache both do this in order to probe for platform-specific libraries