### PR TITLE
Load from the unpacked section if we're in an ASAR archive

### DIFF
--- a/lib/edge-cs.js
+++ b/lib/edge-cs.js
@@ -1,5 +1,5 @@
 var path = require('path');
 
 exports.getCompiler = function () {
-	return process.env.EDGE_CS_NATIVE || path.join(__dirname, 'edge-cs.dll');
+	return process.env.EDGE_CS_NATIVE || path.join(__dirname, 'edge-cs.dll').replace('app.asar', 'app.asar.unpacked');
 };


### PR DESCRIPTION
Electron applications are often packed in a tarball-like format called ASAR, which resolves the path-too-long issues as well as saves on CreateFile calls. However, in order to load native DLLs, certain files are stored in the "unpacked" section, since Win32 obviously can't load DLLs out of ASAR archives - this PR allows you to load edge-cs out of an ASAR archive. 