### PR TITLE
Issue#12: Fixing install.js failure

### DIFF
--- a/tools/install.js
+++ b/tools/install.js
@@ -12,7 +12,7 @@ function whereis() {
     		var filename = arguments[j];
 	        var filePath = path.join(directories[i], filename);
 
-	        if (fs.existsSync(filePath)) {
+	        if (fs.existsSync(filePath) && fs.lstatSync(filePath).isFile()) {
 	            return filePath;
 	        }
 	    }


### PR DESCRIPTION
See Issue#12 for details of this bug

  * https://github.com/tjanczuk/edge-cs/issues/12

For fixing, this patch limit `whereis`
to only match file name rather than folder
name.